### PR TITLE
Update the baseurl to /team, to hopefully get the blog rendered correctly againc

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Rust Network Services Working Group
-baseurl: "/wg-net"
+baseurl: "/team"
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Build settings


### PR DESCRIPTION
Should fix most of #92. 

You can see that the URLs should be properly generated at https://timnn.github.io/rustasync-team/ (Note that the repository is named differently on my account, so things look broken, but the sources show the correct `/team/` urls).