### PR TITLE
Fix 3 broken rust-lang-nursery.github.io links

### DIFF
--- a/_posts/2018-09-11-tide.md
+++ b/_posts/2018-09-11-tide.md
@@ -5,7 +5,7 @@ author: Aaron Turon
 date:   2018-09-11
 ---
 
-The Network Services Working Group [aims to](https://rust-lang-nursery.github.io/team/web-foundations/) improve the story for web development this year in several respects: by bolstering foundations like async/await, by improving the ecosystem of web-related crates, and by pulling these pieces together into a framework and book called *Tide*. The name “Tide” refers to “*a rising tide lifts all boats*”; the intent is to improve sharing, compatibility, and improvements across *all* web development and frameworks in Rust.
+The Network Services Working Group [aims to](https://rustasync.github.io/team/web-foundations/) improve the story for web development this year in several respects: by bolstering foundations like async/await, by improving the ecosystem of web-related crates, and by pulling these pieces together into a framework and book called *Tide*. The name “Tide” refers to “*a rising tide lifts all boats*”; the intent is to improve sharing, compatibility, and improvements across *all* web development and frameworks in Rust.
 
 # The role of web frameworks
 

--- a/_posts/2018-10-16-tide-routing.md
+++ b/_posts/2018-10-16-tide-routing.md
@@ -17,7 +17,7 @@ This post continues the [series on Tide][last-post], sketching a *possible* desi
 
 The two concerns are usually somewhat coupled, because the extraction strategy shapes the signature of the endpoints that are being routed to. As we'll see in this post, however, the coupling can be extremely loose.
 
-[last-post]:  https://rust-lang-nursery.github.io/team/2018/09/11/tide.html
+[last-post]:  https://rustasync.github.io/team/2018/09/11/tide.html
 
 **_Nothing in this post is set in stone!_** 
 Rather, this is a sketch of one possible API direction, to 

--- a/_posts/2018-11-27-tide-middleware-evolution.md
+++ b/_posts/2018-11-27-tide-middleware-evolution.md
@@ -16,7 +16,7 @@ marked as good [starter issues], and there's ongoing discussion for what we'd
 like to see in a [0.1 release]. Getting involved now is the best opportunity
 to help shape the direction of this community-built framework!
 
-[last post]: https://rust-lang-nursery.github.io/team/2018/11/07/tide-middleware.html
+[last post]: https://rustasync.github.io/team/2018/11/07/tide-middleware.html
 [starter issues]: https://github.com/rust-net-web/tide/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [0.1 release]: https://github.com/rust-net-web/tide/issues/60
 


### PR DESCRIPTION
While links to https://github.com/rust-lang-nursery/net-wg redirect just fine (due to GitHub's handling of moved repositories), links to the old GitHub pages site at https://rust-lang-nursery.github.io/team/ are now broken.