### PR TITLE
Add roadmap RFC and RFC template.

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,95 @@
+- Feature Name: (fill me in with a unique ident, `my_awesome_feature`)
+- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RustAsync Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the language and you were teaching it to another Rust programmer. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Rust programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Rust programmers and new Rust programmers.
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how the this all fits into the roadmap for the project
+and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -12,6 +12,9 @@ This RFC is intended to provide the general outline and define the goals for the
 
 Since this will be the first sprint for the async ecosystems wg, the goal is to build a good foundation on which future work can proceed.
 
+* Start date: *28 March*
+* End date: *2 May*
+
 # Detailed description
 [detailed-description]: #detailed-description
 
@@ -103,7 +106,11 @@ The book can also provide guides for building different kinds of software using 
 
 Echoing the theme of the sprint, the goals for the book will be to provide a good foundation to build upon.
 
-TODO: Define specific goals?
+Some general goals are
+
+* [ ] Outline chapters
+* [ ] Move Async book to rustasync org?
+* [ ] Provide a guide for writing chapters?
 
 # Library ecosystem
 [library-ecosystem]: #library-ecosystem
@@ -112,7 +119,10 @@ There are a lot of existing libraries which use Future 0.1 . As it stands there 
 
 ### Goals
 
-TODO: Define specific goals?
+Some general goals for this sprint are:
+
+* [ ] Reach out to crate maintainers and learn their requirements
+* [ ] Migrate projects for experience reports.
 
 
 [async-book]: https://rust-lang.github.io/async-book/

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -67,22 +67,54 @@ Currently rust web frameworks have disparate ways of authentication. One of the 
 
 * [ ] Design authentication API in Tide.
 
-# Areweasyncyet
-[Areweasyncyet]: #areweasyncyet
-
-TODO
-
-# Arewewebyet
-[Arewewebyet]: #arewewebyet
-
-TODO
-
 [issues]: https://github.com/rustasync/tide/issues/
 [context-pr]: https://github.com/rustasync/tide/pull/156
 [issues-9]: https://github.com/rustasync/tide/issues/9
 [issues-99]: https://github.com/rustasync/tide/issues/99
 [issues-63]: https://github.com/rustasync/tide/issues/63
 [issues-24]: https://github.com/rustasync/tide/issues/24
+
 [sprint-goals]: https://github.com/rustasync/team/issues/96
 [goals-outline]: https://github.com/rustasync/team/issues/96#issuecomment-471552499
 [session-project]: https://github.com/tomhoule/tide-cookie-session
+
+# Websites
+[websites]: #websites
+
+There are two primary websites for keeping tack of async await progress and web development progress:
+
+* [Areweasyncyet][areweasyncyet]
+* [Arewewebyet][Arewewebyet]
+
+There isn't a lot that has been discussed around these two as they are in maintenance mode and work will mostly be around updating the content as and when appropriate.
+
+[areweasyncyet]: https://areweasyncyet.rs/
+[arewewebyet]: http://www.arewewebyet.org/
+
+# Async book
+[async-book]: #async-book
+
+The current [Async book][async-book] is a great start at explaining the details of why `async/await` is important, but is light on the details. As mentioned in [this issue][lucio-issue], there are discussions on improving the contents and providing a starting point for people wanting to learn about how the feature works. There are also plans for adding sections for helping maintainers of existing libraries to migrate to std futures.
+
+The book can also provide guides for building different kinds of software using `async/await` as well as provide guides for people wanting to help out with the documentation and migration effort, akin to [Tokio's doc-blitz][doc-blitz].
+
+
+### Goals
+
+Echoing the theme of the sprint, the goals for the book will be to provide a good foundation to build upon.
+
+TODO: Define specific goals?
+
+# Library ecosystem
+[library-ecosystem]: #library-ecosystem
+
+There are a lot of existing libraries which use Future 0.1 . As it stands there is no resource to refer to when a library maintainer would want to port their library to work with std futures. [The issue][lucio-issue] mentioned in the previous section goes into more detail, but the general theme is to provide material and help for library maintainers to migrate their libraries to std Futures.
+
+### Goals
+
+TODO: Define specific goals?
+
+
+[async-book]: https://rust-lang.github.io/async-book/
+[lucio-issue]: https://github.com/rustasync/team/issues/102
+[doc-blitz]: https://tokio.rs/blog/2018-10-doc-blitz/

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -109,8 +109,8 @@ Echoing the theme of the sprint, the goals for the book will be to provide a goo
 Some general goals are
 
 * [ ] Outline chapters
-* [ ] Move Async book to rustasync org?
-* [ ] Provide a guide for writing chapters?
+* [ ] Move Async book to rustasync org
+* [ ] Provide guides for writing chapters.
 
 # Library ecosystem
 [library-ecosystem]: #library-ecosystem

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -1,0 +1,88 @@
+- Feature Name: N/A
+- Start Date: (fill me in with today's date, 2019-03-27)
+- RFC PR: [rust-lang/rfcs#0000](https://github.com/rust-lang/rfcs/pull/0000)
+- RustAsync Issue: [rust-lang/rust#0000](https://github.com/rust-lang/rust/issues/0000)
+
+# Summary
+[summary]: #summary
+
+The roadmap for the first 6 week for the Rustasync ecosystem work group.
+
+This RFC is intended to provide the general outline and define the goals for the first sprint. The 6 week sprint provides a block time long enough to take a feature to completion, while at the same time being short enough that things do not stagnate.
+
+Since this will be the first sprint for the async ecosystems wg, the goal is to build a good foundation on which future work can proceed.
+
+# Detailed description
+[detailed-description]: #detailed-description
+
+# Tide
+[tide]: #tide
+
+The project has seen a lot of discussion happen in [issues][issues] as well as the discord channel. The general conversation currently revolves around getting the core framework stabilized in order to build features on top of that. To this end, the currently [open PR by @aturon][context-pr] works to refactor the way data is passed along to endpoint functions. This change is a major change allowing data extraction to be more explicit.
+
+ Once this feature lands, here are some of the issues that work can begin on:
+
+ * [Authentication in Tide][issues-99]
+ * [Serving static files][issues-63]
+ * [URL generation][issues-24]
+
+There has been some discussion on the [Sprint 1 goals issue][sprint-goals], and a really good overview for the features to work on has been been [outlined by @gruberb][goals-outline]. This outline a great basis to set up the roadmap for Tide. It consists of the following broad goals:
+
+* [  ] Stabilize tide core.
+* [  ] Session management
+* [  ] Authentication
+
+## Stabilize tide core
+[stabilize-tide-core]: #stabilize-tide-core
+
+Currently [the PR][context-pr] is open, with most of the core changes done. There is ongoing discussion regarding the change, and you can follow with the progress directly on the PR.
+
+
+### Goals
+[stabilize-core-goals]: #stabilize-core-goals
+
+* [  ] Merge PR
+* [  ] Resolve design questions.
+
+## Session management
+[session-management]: #session-management
+
+Current discussion around session management in tide is centered around the [design issue][issues-9] for the same. @tomhoule has got a working generic session implementation written against the new tide core changes. You can check the [project out here][session-project]. This provides types to define middleware and custom session storage backends which hook directly into the `Context` object proided to the endpoint function.
+
+The current discussion is centered on providing a simple in memory session storage with Cookies as the default in the framework, and provide external crates to hook into external data stores.
+
+This change is currently blocked by the tide core changes.
+
+### Goals
+
+* [  ] Stable API.
+* [  ] In memory session backend
+
+## Authentication
+[Authentication]: #authentication
+
+Currently rust web frameworks have disparate ways of authentication. One of the goals of the Async ecosystem WG is to provide a common set of crates which can be used to build higher level abstractions. In terms of Tide, there currently isn't an authentication story present. @tomhoule has built cookie based authentication into the session management middleware as a POC. Therefore the goals for this sprint would be to sketch out the design of the authentication API for tide.
+
+### Goals
+
+* [  ] Design authentication API in Tide.
+
+# Areweasyncyet
+[Areweasyncyet]: #areweasyncyet
+
+TODO
+
+# Arewewebyet
+[Arewewebyet]: #arewewebyet
+
+TODO
+
+[issues]: https://github.com/rustasync/tide/issues/
+[context-pr]: https://github.com/rustasync/tide/pull/156
+[issues-9]: https://github.com/rustasync/tide/issues/9
+[issues-99]: https://github.com/rustasync/tide/issues/99
+[issues-63]: https://github.com/rustasync/tide/issues/63
+[issues-24]: https://github.com/rustasync/tide/issues/24
+[sprint-goals]: https://github.com/rustasync/team/issues/96
+[goals-outline]: https://github.com/rustasync/team/issues/96#issuecomment-471552499
+[session-project]: https://github.com/tomhoule/tide-cookie-session

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -35,8 +35,8 @@ There has been some discussion on the [Sprint 1 goals issue][sprint-goals], and 
 * [ ] Session management
 * [ ] Authentication
 
-## Stabilize tide core
-[stabilize-tide-core]: #stabilize-tide-core
+## Merge Context PR
+[merge-context-pr]: #merge-context-pr
 
 Currently [the PR][context-pr] is open, with most of the core changes done. There is ongoing discussion regarding the change, and you can follow with the progress directly on the PR.
 

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -96,7 +96,7 @@ There isn't a lot that has been discussed around these two as they are in mainte
 
 The current [Async book][async-book] is a great start at explaining the details of why `async/await` is important, but is light on the details. As mentioned in [this issue][lucio-issue], there are discussions on improving the contents and providing a starting point for people wanting to learn about how the feature works. There are also plans for adding sections for helping maintainers of existing libraries to migrate to std futures.
 
-The book can also provide guides for building different kinds of software using `async/await` as well as provide guides for people wanting to help out with the documentation and migration effort, akin to [Tokio's doc-blitz][doc-blitz].
+The book can also provide guides for building different kinds of software using `async/await` as well as provide guides for people wanting to help out with the documentation and migration effort, akin to [Tokio's doc-push][doc-push].
 
 
 ### Goals
@@ -117,4 +117,4 @@ TODO: Define specific goals?
 
 [async-book]: https://rust-lang.github.io/async-book/
 [lucio-issue]: https://github.com/rustasync/team/issues/102
-[doc-blitz]: https://tokio.rs/blog/2018-10-doc-blitz/
+[doc-push]: https://tokio.rs/blog/2018-10-doc-blitz/

--- a/rfcs/0001-tide-roadmap.md
+++ b/rfcs/0001-tide-roadmap.md
@@ -28,9 +28,9 @@ The project has seen a lot of discussion happen in [issues][issues] as well as t
 
 There has been some discussion on the [Sprint 1 goals issue][sprint-goals], and a really good overview for the features to work on has been been [outlined by @gruberb][goals-outline]. This outline a great basis to set up the roadmap for Tide. It consists of the following broad goals:
 
-* [  ] Stabilize tide core.
-* [  ] Session management
-* [  ] Authentication
+* [ ] Stabilize tide core.
+* [ ] Session management
+* [ ] Authentication
 
 ## Stabilize tide core
 [stabilize-tide-core]: #stabilize-tide-core
@@ -41,13 +41,13 @@ Currently [the PR][context-pr] is open, with most of the core changes done. Ther
 ### Goals
 [stabilize-core-goals]: #stabilize-core-goals
 
-* [  ] Merge PR
-* [  ] Resolve design questions.
+* [ ] Merge PR
+* [ ] Resolve design questions.
 
 ## Session management
 [session-management]: #session-management
 
-Current discussion around session management in tide is centered around the [design issue][issues-9] for the same. @tomhoule has got a working generic session implementation written against the new tide core changes. You can check the [project out here][session-project]. This provides types to define middleware and custom session storage backends which hook directly into the `Context` object proided to the endpoint function.
+Current discussion around session management in tide is centered around the [design issue][issues-9] for the same. @tomhoule has got a working generic session implementation written against the new tide core changes. You can check the [project out here][session-project]. This provides types to define middleware and custom session storage backends which hook directly into the `Context` object provided to the endpoint function.
 
 The current discussion is centered on providing a simple in memory session storage with Cookies as the default in the framework, and provide external crates to hook into external data stores.
 
@@ -55,8 +55,8 @@ This change is currently blocked by the tide core changes.
 
 ### Goals
 
-* [  ] Stable API.
-* [  ] In memory session backend
+* [ ] Stable API.
+* [ ] In memory session backend
 
 ## Authentication
 [Authentication]: #authentication
@@ -65,7 +65,7 @@ Currently rust web frameworks have disparate ways of authentication. One of the 
 
 ### Goals
 
-* [  ] Design authentication API in Tide.
+* [ ] Design authentication API in Tide.
 
 # Areweasyncyet
 [Areweasyncyet]: #areweasyncyet


### PR DESCRIPTION
This PR adds a template for creating RFCs and a RFC for the upcoming 1st rust async ecosystem sprint.

[Rendered](https://github.com/bIgBV/team/blob/tide-roadmap/rfcs/0001-tide-roadmap.md)

I have filled in the tide parts of the roadmap, and will work with @yoshuawuyts to fill in the rest of the roadmap.