### PR TITLE
Add notes for february, march and april 2019

### DIFF
--- a/meetings/2019-02-14.md
+++ b/meetings/2019-02-14.md
@@ -1,0 +1,61 @@
+## Working Group Updates
+  - Status updates
+    - tide
+    - docs
+  - All-hands recap
+  - Add WG agenda items here…
+    - Can we get alignment between Tide’s middleware and Tower’s middleware? 
+    - Missing gaps in the ecosystem
+
+## Revamping the structure of the WG
+
+- Initially structured as three “sub” WGs:
+  - async
+  - embedded
+  - web
+- Proposed structure
+  - network foundations (lang/compiler/`std`)
+  - network ecosystem
+
+## Survey review
+
+- Biggest takeaway: lack of documentation and examples is a major problem in the Rust async world right now
+- People also want a “one true framework” / more obvious default choice
+- Still lots of gaps in the web ecosystem
+  - client libraries for message queues
+  - async database drivers
+- Summary post
+- aturon wants to review detailed responses to make an “ecosystem TODO list”
+
+## Update on the state of networking
+
+- Rust team All Hands
+  - 3 sessions on Tide
+    - mostly introducing people to Tide
+    - some high-level API review
+    - CSRF issues
+  - 3 sessions on async + futures
+    - No decision  yet  on final `await` syntax, but some progress on process to get there
+    - session on futures 1.0 👍 
+    - futures RFC is in FCP
+
+## Tide
+
+- progress has been steady, even in absence of meetings
+- API Design notes
+  - we’d like to explore different API designs outside of extractors
+    - Tide could move to a more “layered” structure, where each endpoint is `async fn(RequestContext) - > Response`.
+    - A branch + writeup are planned to explore this direction further
+  - We’re thinking of moving to a highly iterative approach, where we can release new Tide versions early + often
+    - Create a split between “core” functionality, and ergonomics that can be layered on top
+    - The plan will be laid out more concretely in issues/RFCs
+
+## Async
+
+- Concerns about how the process around futures and async/await has progressed —  there’s a large disconnect between the public github threads and private discussions amongst team members, which feels bad for everyone
+
+## Middleware ([http-service](https://docs.rs/http-service/0.1.1/http_service/) + [tower](https://docs.rs/tower/0.0.1/tower/))
+
+- Lots of overlap between what these two crates are trying to do
+- The http-service crate is intended to be framework-neutral, and collaboration is super important there
+- However, there’s a lot of detail work to figure out how to fit this together in a way that works for Tide, Tower, and others

--- a/meetings/2019-02-21.md
+++ b/meetings/2019-02-21.md
@@ -1,0 +1,32 @@
+## Working Group Updates
+  - Recurring meeting slot (poll)
+    - Finalized to Thu 10AM-11AM CST
+  - Tide issue triage
+    - Initial triage on 2019-02-22 10AM - 11AM CST
+    - Once initial triage is done, recurring triage will occur during the weekly meetings
+  - Status updates
+    - tide
+      - @Aaron T submitted a new PR refactoring the internals of tide to use the new http-service crate
+      - for http-service, the goals are:
+        - to provide an interface that is not tied in to any particular framework or server
+        - to work with futures 0.3 directly
+        - to avoid generics as much as possible, to keep the type system aspects relatively easy
+    - WG structure
+      - `rustasync` will be the umbrella org for the rust asynchronous ecosystem with two major focuses
+      - One would be the async foundations which overlaps with the compiler team and works to add async features to the languages
+      - The other will be async ecosystem, which focuses on the broader async ecosystem
+        - Quoting @yoshua w :
+        > being about networking, the scope of the async ecosystem WG would also include bindings to platforms, reactors, thread pools, and traits to bind them together
+
+## Office Hours
+  - Web WG is growing: Can we list the core areas of the “new” WG?
+  - What is the most urgent area where help is needed? Tide? Core-Crates? 
+  - What other ways are there to help out except PRs?
+  - What’s the timeline for the first version of Tide and how many people are currently working on it?
+  - //Maybe an offtopic question: How would you position Rust/Tide vs. NodeJS and Go. What are the arguments you would tell a company/shop to use Rust/Tide instead of Node or Go?
+  - Get a stable core framework up and running from which point we can start semver versioning.
+  - The triage meeting happening tomorrow and the triage which will happen during the weekly meeting would be a great entry point for onboarding contributors.
+- Mentorship
+  - Are there any plans for providing mentorship to new contributors?
+    - Similar to the previous question, the triage meetings would be a great point to start the onboarding of new contributors.
+  - How would this be structured?

--- a/meetings/2019-02-28.md
+++ b/meetings/2019-02-28.md
@@ -1,0 +1,29 @@
+## Working Group Updates
+  - Status updates
+    - tide
+      - Outcome of the triage from last Friday. 
+        - Need to discuss owner structure of crates and who is able to update/publish them. 
+        - Figuring out to make the whole WG as a maintainer of a crate: `cargo owner --add "github:rustasync:maintainers"`
+        - Merged @Bastian G `http-service-mock` crate 
+        - @V B Looked into session management (mainly Rocket, actix-web and tower-web) and how we could implement it in tide. He also looked into URL generation. Django and Flask are using a stringly typed API, which we want to avoid
+      - @Sendil K proposed to be able to serve static files (issue)
+  - Gaps in the ecosystem
+    - [2019-02-27 Web Ecosystem Gaps](https://paper.dropbox.com/doc/2019-02-27-Web-Ecosystem-Gaps--AbDiGEkEgke46uLrPDgEOn6ZAg-1DSQhREQVJYGirBelosBY) 
+      - Going through the survey points. This document is a great starting point for anyone who wants to contribute to the ecosystem
+      - Creating a guide like tokio doc-blitz 
+      - Crates could be linked to [AreWeWebYet](http://www.arewewebyet.org/)?
+      - Discussion of how to point to the next priority to work on and where to share progress. Libraries are not synced with the latest progress (like futures 0.3) and people are waiting for things to finalize and stabilize
+      - Update areweasyncyet to point to which futures version is supported
+      - Link areweasyncyet to async-book
+      - Summary of the discussion:  “we have a consensus that for now we should't engage in building a new list, we shouldn't put out a call for implementations, but we should start making futures 0.3/1.0 projects more discoverable”
+  - Async WG transition updates
+    - wg-net site
+    - rust-lang.org (team repo)
+    - Discord channel, wg-net repo and website still need to be moved to the new org structure. @Aaron T is needed for this because of admin rights
+    - Discrod channel should be under “domain working groups” in the future, but needs to be clarified. @yoshua w is coordinating it.
+    - Joint meeting with async foundation wg is planned, and more check ins in the future
+    - Blog post or primer on how to get involved with the group with details 
+          
+## Office Hours
+  - Extractor or Resource download option for the tide ([PR]( https://github.com/rustasync/tide/pull/126))
+    - PR is stalled, suggestion to treat static file serving as a separate concern and implement it into the middleware 

--- a/meetings/2019-03-07.md
+++ b/meetings/2019-03-07.md
@@ -1,0 +1,37 @@
+## Working Group Updates
+  - Status updates
+    - tide
+      - Core idea is to create the “smallest” core API as possible
+      - The goals are:
+        - Taking care of http-related concerns at “signature” level
+        - Working with application types instead of http types
+        - Current downsides of the extractor setup are dealing with wrapper types, some magic impls of the Endpoint trait which makes it overall hard to use and understand
+      - @Aaron T is working on revamp to make it easier to use and understand
+        - The goal is to write endpoints directly and extract data within the body instead of having various Endpoint impls for extractor arguments
+        - Extractions (could) happen inside the endpoint body instead of getting passed as parameters. However, the seperation of http and application would weaken
+        - Using attribute macros to extract parameters to keep the function bodies “app native”
+        - @Aaron T will write up a lengthy proposal for this change (proposal). Generally great feedback from the working group
+    - wg transition
+      - We have rustasync GitHub handle
+      - We fixed the blog and the urls
+      - Still missing: rust-lang.org, discord and twitter, rustasync
+        - Website: @yoshua w 
+        - Twitter: @Aaron T 
+        - Discord: @Aaron T 
+        - rustasync: Will be an issue on GitHub
+      - Need to give access rights to team members to transition ownership from private crate to rustasync
+    - arewewebyet
+      - Looking for maintainers and doing active curation within the team
+      - Probably takes 10 minutes a week to keep it updated and curated
+      - Long term vision: AWWY could be a key role in communicating, together with the working group and areweasync yet
+    - areweasyncyet
+      - Constant updates, need to get upsuper joining the next meeting
+    - [2019 roadmap](https://github.com/rustasync/team/issues/96)
+      - Read it and give feedback 😉 
+  - 6 week sprints
+    - WASM WG is starting with 6 week sprint cycles (again)
+    - Use this also for our working group to plan work in terms of time and setting goals
+    - Having a road map according to the 6 week cycle
+    - Creating an issue with first thoughts - [https://github.com/rustasync/team/issues/96](https://github.com/rustasync/team/issues/96)
+  - Issue triage (org | tide)
+    - No time left, first point on the agenda for next meeting

--- a/meetings/2019-03-14.md
+++ b/meetings/2019-03-14.md
@@ -1,0 +1,34 @@
+## Working Group Updates
+  - Status updates (10 mins)
+    - tide
+      - Updates on the [route-match algorithm](https://github.com/rustasync/tide/issues/141). 
+    - areweasyncyet
+      - Upsuper won’t make it to the meetings because of time difference. Goals would be to add a bit automation to keep things updated. Not much plans otherwise, so suggestions are welcome.
+    - arewewebyet
+      - A few curation PRs to prune unmaintained crates, steady progress
+      - List of all “are we xy yet” is at the MozillaWiki: https://wiki.mozilla.org/Areweyet
+    - romio + juliex
+      - Moving both repos to the org soon, have to find the time to do that 
+    - async foundations
+      - http://smallcultfollowing.com/babysteps/blog/2019/03/01/async-await-status-report/
+      - Discord and twitter still need to be updated; time is (as always) very limited
+      - In talks to schedule a regular checkin meeting wit the async foundations WG
+      - asnyc foundation WG also open to have sprints
+  - 6 week sprints (25 mins)
+    - https://github.com/rustasync/team/issues/96
+    - Helpful to define metrics (“we support X after this sprint”…)
+    - After the sprint we want to have a small and well defined example app
+    - The tide rewrite should have been merged 
+    - Finished and stabilized the “core” (PR/issue need to define what exactly is included in the core)
+    - Generally raising concerns about the direction of the WG and tide, which will be talked at another time (https://github.com/rust-lang/rfcs/pull/2657#issuecomment-471643874) 
+    - The extractor interface change needs to happen in this sprint as well, which is a blocker for future work on the middleware
+    - Another sprint goal is to come up with a websockets design
+  - Issue triage ([org](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Arustasync) | [tide](https://github.com/rustasync/tide/issues/))(25 mins)
+    - https://github.com/rustasync/tide/issues/152
+      - Logging vs Tracing: Logging prio 1
+      - Solution (and talked about previously) was to use a log middleware create which just calls the log macros instead of setting up a logger
+    - Moving session management (https://github.com/rustasync/tide/issues/9) to the core
+    - Proposed “documentation” label 
+
+## Office Hours
+  - No office hours this week.

--- a/meetings/2019-03-28.md
+++ b/meetings/2019-03-28.md
@@ -1,0 +1,23 @@
+## Working Group Updates
+  - Status updates
+    - tide
+      - Discussions around @Aaron T PR about the big rewrite. Some concerns about declerative vs. imperative and passing the whole state in every route. Examples should clarify the concerns soon.
+    - areweasyncyet
+      - maintenance mode and just needs updates whenever features are getting stabilized
+    - arewewebyet
+      - PR with updated WASM topic
+      - We still need to figure out access writes to close the currently 11 open PRs Fixed
+      - Changing engine from jekyll to cobalt, but not a priority right now
+      - Cleanup is still in progress
+    - romio + juliex
+      - @yoshua w put out a new release for both last week
+      - Juliex now as a thread pool initialization hook; useful for setting up TLS
+      - Romio exposes new contructors (like TryFrom<std::netTcpListener>
+        - https://github.com/yoshuawuyts/async-ready
+        - https://github.com/yoshuawuyts/async-datagram
+  - Issue triage (org | tide)
+    - skip because of the blocking rewrite PR which needs to be merged first
+  - Other WG agenda items
+    - Start putting async-book and futures on the weekly agenda
+      - Brainstorm async-book chapter ideas so people can pick them up and write about them
+    - Disucssions around keeping track of async realted topics; hard to keep track of what’s floating around

--- a/meetings/2019-04-04.md
+++ b/meetings/2019-04-04.md
@@ -1,0 +1,31 @@
+## Six-Week Sprint
+  - End date: 2019-05-02 (six weeks)
+  - Sprint goals
+
+## Working Group Updates
+  - Status updates
+    - futures
+      - Transition to 0.3 is mostly done
+      - Cleanup the “disabled” parts of the code base still needs to happen
+      - AsyncSeek trait still needs to be added (besides other features)
+      - Getting more users to try it out is a key to figure out what is still missing
+      - There are still a few broken doc links which need to be fixed
+    - romio + juliex
+      - Not much happened in the last week
+      - A  new bug was filed (link) and being triaged
+    - async rust book
+      - Hold off until Futures are stabilized (Just the Futures API, not all of AsyncRead, AsyncWrite etc.)
+      - This might happen soon though 
+    - arewewebyet
+      - WASM topic updated
+      - All current PRs are merged
+      - Current focus: content
+      - Next topic will  be infrastructure tasks
+    - tide
+      - @Aaron T will finish up the blocking rewrite PR asap
+      - Other improvements (endpoint errors) will be outlined in a GitHub issue
+      - Nested apps will be discussed in a future PR
+  - Issue triage (org | tide)
+  - Add WG agenda items here…
+    - Add http-service to future agendas 
+    - Lets start each meeting with the Sprint Goals/Roadmap


### PR DESCRIPTION
Based on this [issue](https://github.com/rustasync/team/issues/60#issuecomment-482029257) we want to continue publish the meeting notes.

I have separated each meeting from the Dropbox Paper document and created one file for each day. 