### PR TITLE
fix team links in header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,19 +3,19 @@
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
 
-    <a class="header-link" href="/wg-net/">Rust Network Services Working Group</a>
+    <a class="header-link" href="/team/">Rust Network Services Working Group</a>
 
     <div class="menu">
 
-      <a class="menu-link" href="/wg-net/async-foundations">
+      <a class="menu-link" href="/team/async-foundations/">
         Async
       </a>
 
-      <a class="menu-link" href="/wg-net/embedded-foundations">
+      <a class="menu-link" href="/team/embedded-foundations/">
         Embedded
       </a>
 
-      <a class="menu-link" href="/wg-net/web-foundations">
+      <a class="menu-link" href="/team/web-foundations/">
         Web
       </a>
 


### PR DESCRIPTION
Previously, header links pointed to /wg-net/:name/, but this website is
located at https://rustasync.github.io/team/.

This change prevents users from receiving 404 errors.