### PR TITLE
Add minutes for 04/18/2019

### DIFF
--- a/meetings/2019-04-18.md
+++ b/meetings/2019-04-18.md
@@ -1,0 +1,35 @@
+
+## Six-Week Sprint  
+    - End date: 2019-05-02 (six weeks)
+    - [Sprint goals](https://github.com/rustasync/team/blob/master/rfcs/0001-tide-roadmap.md)
+        - Roadmap needs to be updated with already completed items
+        - Open PR which adds cookie middleware and it’s associated extension trait
+            - We need to find a way to bring all extension traits into scope without manually add every one of them
+        - Lots of open PRs and work around tide in the last week
+
+## Working Group Updates  
+    - Status updates
+        - tide
+            - Work on various crates to be compatible with the latest futures API on nightly
+            - tide 0.1.0 release
+            - Lots of discussions around authentication, static files and URL generation which is also on the roadmap for this sprint
+                - Experimental implementation for serving static files ([GitHub](https://github.com/tomhoule/tide-static-files))
+            - Dedicated issue for figuring out cross-framework middleware ([issue](https://github.com/rustasync/tide/issues/164))
+                - A path for that would be to find some least-common denominator trait for middleware, and then focus on developing cross-framework middleware 
+            - Discussion needs to happen around crates which add functionality to tide. Discussion will happen on the RFC thread ([issue](https://github.com/rustasync/tide/issues/162))
+        - futures
+            - Big breaking change (Context + Pin projection on the streams traits)
+            - Sink is now generic over its item, makes it possible to implement it multiple times for a single type
+            - FutureObj is deprecated, need to be swapped out for Pin<Box<dyn Future>> (will have an alias)
+            - async specifics might move behind a feature so that we can have a version that will compile on 1.36 when futures_api is stable
+        - runtime
+            - Crate was released earlier this week ([reasoning](https://blog.yoshuawuyts.com/runtime/) | [crate](https://github.com/rustasync/runtime))
+            - It abstracts romio+juliex, tokio and others in the future
+            - It lives under the rustasync org 
+        - romio + juliex
+            - no time for it this meeting
+        - async rust book
+            - No progress this week
+        - arewewebyet
+            - no time for it this meeting
+    - Issue triage ([org](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+user%3Arustasync) | [tide](https://github.com/rustasync/tide/issues/))


### PR DESCRIPTION
Adding minutes for todays meeting.

Ping @aturon for additional info about process on getting it on the Rust Forum and out on twitter.